### PR TITLE
Use with context manager to handle file access

### DIFF
--- a/build_yaml_macros.py
+++ b/build_yaml_macros.py
@@ -18,12 +18,12 @@ class BuildYamlMacrosCommand(sublime_plugin.WindowCommand):
 
         if extension != '.yaml-macros': raise "Not a .yaml-macros file!"
 
-        output_file = open(output_path, 'w')
+        with open(output_path, 'w') as output_file:
 
-        build_yaml_macros(
-            view.substr( sublime.Region(0, view.size()) ),
-            output_file,
-            {
-                "file_path": source_path
-            },
-        )
+            build_yaml_macros(
+                view.substr( sublime.Region(0, view.size()) ),
+                output_file,
+                {
+                    "file_path": source_path
+                },
+            )


### PR DESCRIPTION
Currently, after the build completes the output file is not closed, and so it remains locked and is unable to be edited by other processes.