### PR TITLE
Updated example syntax file extensions, added context manager for file read

### DIFF
--- a/examples/jsx/JavaScript.sublime-syntax
+++ b/examples/jsx/JavaScript.sublime-syntax
@@ -4,8 +4,8 @@
 name: JavaScript
 hidden: true
 file_extensions:
-  - js
-  - htc
+  - js.example
+  - htc.example
 first_line_match: ^#!\s*/.*\b(node|js)\b
 scope: source.js.example
 variables:

--- a/examples/jsx/jsx.sublime-syntax
+++ b/examples/jsx/jsx.sublime-syntax
@@ -3,8 +3,8 @@
 name: JSX (YAML Macros example)
 hidden: true
 file_extensions:
-- js
-- htc
+- js.example
+- htc.example
 first_line_match: ^#!\s*/.*\b(node|js)\b
 scope: source.js.example
 variables:
@@ -342,7 +342,7 @@ contexts:
       - meta_scope: meta.block.js
 
       - match: (?=\})
-        pop: true  
+        pop: true
 
       - match: \b(case)\b
         scope: keyword.control.switch.js

--- a/lib/extend.py
+++ b/lib/extend.py
@@ -32,5 +32,6 @@ def extend(*items):
     base = extension['_base']
     del extension['_base']
 
-    syntax = yaml.load( open(base, 'r') )
+    with open(base, 'r') as base_file:
+        syntax = yaml.load(base_file)
     return Merge(extension).apply(syntax)


### PR DESCRIPTION
I note that for the SQL example syntax you just don't include any file extensions, so perhaps you would prefer to just remove them from the example JS ones as well?