### PR TITLE
Redo errors reporting

### DIFF
--- a/build_yaml_macros.py
+++ b/build_yaml_macros.py
@@ -1,36 +1,25 @@
 import sublime
 import sublime_plugin
 
-import os
-from os import path
-
 from YAMLMacros.api import build
 from YAMLMacros.src.output_panel import OutputPanel
 from YAMLMacros.src.error_highlighter import ErrorHighlighter
 
 class BuildYamlMacrosCommand(sublime_plugin.WindowCommand):
-    def run(self, *, source_path=None, destination_path=None, working_dir=None, arguments={}, build_id='YAMLMacros'):
-        if working_dir:
-            os.chdir(working_dir)
+    def run(self, *, source_path=None, target_path=None, working_dir=None, arguments={}, build_id='YAMLMacros'):
+        error_stream = OutputPanel(self.window, build_id)
 
-        if not source_path:
+        if source_path is None:
             source_path = self.window.active_view().file_name()
 
-        with open(source_path, 'r') as source_file:
-            source_text = source_file.read()
-
-        if not destination_path:
-            destination_path, extension = path.splitext(source_path)
-            if extension != '.yaml-macros':
-                raise TypeError("Not a .yaml-macros file! Hint: add .yaml-macros extension.")
-
         arguments['file_path'] = source_path
+        arguments['working_dir'] = working_dir
 
         build(
-            source_text=source_text,
-            destination_path=destination_path,
+            source_path=source_path,
+            target_path=target_path,
             arguments=arguments,
-            error_stream=OutputPanel(self.window, build_id),
+            error_stream=error_stream,
             error_highlighter=ErrorHighlighter(self.window, 'YAMLMacros'),
         )
 

--- a/src/build.py
+++ b/src/build.py
@@ -1,23 +1,39 @@
+import os
+from os import path
 import traceback
 import time
-from os import path
 
 from YAMLMacros.api import process_macros
 from YAMLMacros.api import get_yaml_instance
 from YAMLMacros.src.engine import MacroError
 
-def build(source_text, destination_path, error_stream, arguments, error_highlighter):
+
+EXT_DOT_SUBLIME_SYNTAX_YAML_MACROS = '.sublime-syntax.yaml-macros'
+
+
+class SilentException(Exception):
+    """Control-flow exception, assumes that the actual error was already handled."""
+
+
+def build(source_path, target_path, error_stream, arguments, error_highlighter):
+    # Note: messages indicating key phases of the build process are right-aligned
+    # on their first word, which is a verb like 'Compiling', 'Finished' etc.
+    # Current width is 12 characters, excluding white-space after verb.
+
     t0 = time.perf_counter()
 
-    error_stream.print('Building %s... (%s)' % (path.basename(arguments['file_path']), arguments['file_path']))
-
-    def done(message):
-        error_stream.print('[{message} in {time:.2f} seconds.]\n'.format(
-            message=message,
-            time = time.perf_counter() - t0
-        ))
+    def done(ok: bool):
+        if ok:
+            message = '   [Finished in {elapsed:.1f}s]'
+        else:
+            # Not worth aligning, since errors are already cluttering the screen anyway.
+            message = '[Finished in {elapsed:.1f}s with errors]'
+        elapsed = time.perf_counter() - t0
+        error_stream.print(message.format(elapsed=elapsed))
 
     def handle_error(e):
+        if isinstance(e, SilentException):
+            return
         if isinstance(e, MacroError):
             error_stream.print()
             error_stream.print(e.message)
@@ -37,15 +53,41 @@ def build(source_text, destination_path, error_stream, arguments, error_highligh
             error_stream.print(''.join(traceback.format_exception(None, e, e.__traceback__)))
 
     try:
+        # Derive target from source, if not set explicitly.
+        if target_path is None:
+            # Assume that source is a `*.sublime-syntax.yaml-macros` file,
+            # so the target would be just `*.sublime-syntax` without `.yaml-macros` extension.
+            target_path, _ = path.splitext(source_path)
+
+        error_stream.print('   Compiling %s (%s)' % (path.basename(source_path), source_path))
+
+        # Bail out if file extension is not supported.
+        if not source_path.endswith(EXT_DOT_SUBLIME_SYNTAX_YAML_MACROS):
+            # Just a regular message, shouldn't be right-aligned.
+            error_stream.print()
+            error_stream.print('Error: Source is not a YAML Macros file!')
+            error_stream.print('Hint: Make sure source file has `{}` extension.'.format(EXT_DOT_SUBLIME_SYNTAX_YAML_MACROS))
+            error_stream.print()
+            raise SilentException()
+
+        working_dir = arguments['working_dir']
+        if working_dir is not None:
+            os.chdir(working_dir)
+
+        with open(source_path, 'r') as source_file:
+            source_text = source_file.read()
+
         result = process_macros(source_text, arguments=arguments)
+
+        error_stream.print('    Building %s (%s)' % (path.basename(target_path), target_path))
+
+        serializer = get_yaml_instance()
+        with open(target_path, 'w') as output_file:
+            serializer.dump(result, stream=output_file)
+
     except Exception as e:
         handle_error(e)
-        done('Failed')
-        return
+        done(ok=False)
 
-    serializer = get_yaml_instance()
-
-    with open(destination_path, 'w') as output_file:
-        serializer.dump(result, stream=output_file)
-        error_stream.print('Compiled to %s. (%s)' % (path.basename(destination_path), destination_path))
-        done('Succeeded')
+    else:
+        done(ok=True)


### PR DESCRIPTION
Makes all errors and exceptions go to an OutputPanel view. In order to
achieve that, all exception-throwing operations (literally any Python
statement) were moved into the build() function inside the try-catch
block.

I'm not very happy with the control flow exception SilentException, but
exceptions are evil anyway, so that just happened to be the simplest way
to avoid printing dummy traceback.

It also reverses the order of 'Building' and 'Compiling' stages in the
output, because this is how it matches the actual workflow and makes
error reporting at each stage more meaningful, i.e. all errors related
to the source file processing now will be displayed after the
'Compiling <source>' line, and the 'Building <target>' line won't get
reached up until serializing yaml and writing the the target file.

Improves logging format and right-aligns messages on their first word.
Makes '[Finished ...]' line format more consistent with other build
systems, e.g. C Single File from C++ community package.
For example:

```
Compiling Amazing.sublime-syntax.yaml-macros (/AmazingLanguage/Amazing.sublime-syntax.yaml-macros)
 Building Amazing.sublime-syntax (/AmazingLanguage/Amazing.sublime-syntax)
[Finished in 0.0s]
```

And below are logs of some failed builds, ~indented with 2 extra spaces
and~ edited for sensitive filesystem paths.

- Attempt to build something which is not YAML Macros:

```
   Compiling amazing_macros.py (/AmazingLanguage/amazing_macros.py)

Error: Source is not a YAML Macros file!
Hint: Make sure source file has `.sublime-syntax.yaml-macros` extension.

[Finished in 0.0s with errors]
```

- Failed chdir due to nonexistent directory:

```
   Compiling Amazing.sublime-syntax.yaml-macros (/AmazingLanguage/tmp/Amazing.sublime-syntax.yaml-macros)

Traceback (most recent call last):
  File "<Packages>/YAMLMacros/src/build.py", line 77, in build
    os.chdir(working_dir)
FileNotFoundError: [Errno 2] No such file or directory: '/AmazingLanguage/tmp'

[Finished in 0.0s with errors]
```

- Wrong macro name:

```
   Compiling Amazing.sublime-syntax.yaml-macros (/AmazingLanguage/Amazing.sublime-syntax.yaml-macros)

Unknown macro "wraps".
  in "<file>", line 37, column 14

Traceback (most recent call last):
  File "<Packages>/YAMLMacros/src/engine.py", line 64, in multi_constructor
    macro = macros[suffix]
KeyError: 'wraps'

[Finished in 0.0s with errors]
```

- Write-protected target:

```
   Compiling Amazing.sublime-syntax.yaml-macros (/AmazingLanguage/Amazing.sublime-syntax.yaml-macros)
    Building Amazing.sublime-syntax (/AmazingLanguage/Amazing.sublime-syntax)

Traceback (most recent call last):
  File "<Packages>/YAMLMacros/src/build.py", line 85, in build
    with open(target_path, 'w') as output_file:
PermissionError: [Errno 13] Permission denied: '/AmazingLanguage/Amazing.sublime-syntax'

[Finished in 0.0s with errors]
```

Fully fixes #35 