### PR TITLE
Replace mutable default values of arguments

### DIFF
--- a/build_yaml_macros.py
+++ b/build_yaml_macros.py
@@ -6,11 +6,14 @@ from YAMLMacros.src.output_panel import OutputPanel
 from YAMLMacros.src.error_highlighter import ErrorHighlighter
 
 class BuildYamlMacrosCommand(sublime_plugin.WindowCommand):
-    def run(self, *, source_path=None, target_path=None, working_dir=None, arguments={}, build_id='YAMLMacros'):
+    def run(self, *, source_path=None, target_path=None, working_dir=None, arguments=None, build_id='YAMLMacros'):
         error_stream = OutputPanel(self.window, build_id)
 
         if source_path is None:
             source_path = self.window.active_view().file_name()
+
+        if arguments is None:
+            arguments = {}
 
         arguments['file_path'] = source_path
         arguments['working_dir'] = working_dir

--- a/src/engine.py
+++ b/src/engine.py
@@ -87,7 +87,9 @@ def get_parse(input):
 
     return (tree, macros)
 
-def process_macros(input, arguments={}):
+def process_macros(input, arguments=None):
+    if arguments is None:
+        arguments = {}
     with set_context(**arguments):
         tree, macros = get_parse(input)
 

--- a/src/yaml_provider.py
+++ b/src/yaml_provider.py
@@ -9,10 +9,12 @@ def clone_class(klass):
     )
 
 def get_yaml_instance(
-    version = (1, 2),
-    indent = { 'mapping': 2, 'sequence': 4, 'offset': 2 },
+    version=(1, 2),
+    indent=None,
     **kwargs
 ):
+    if indent is None:
+        indent = {'mapping': 2, 'sequence': 4, 'offset': 2}
     yaml = ruamel.yaml.YAML(**kwargs)
 
     yaml.Constructor = clone_class(yaml.Constructor)


### PR DESCRIPTION
Mutable default values considered harmful. They are an anti-pattern in
Python, and should never be used.

https://docs.quantifiedcode.com/python-anti-patterns/correctness/mutable_default_value_as_argument.html