### PR TITLE
Clean up to comply with PEP-8

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,5 +1,14 @@
-from YAMLMacros.src.util import apply, raw_macro
-from YAMLMacros.src.yaml_provider import get_yaml_instance
+from YAMLMacros.src.build import build
 from YAMLMacros.src.engine import process_macros
 from YAMLMacros.src.sublime_resources import get_st_resource
-from YAMLMacros.src.build import build
+from YAMLMacros.src.util import apply, raw_macro
+from YAMLMacros.src.yaml_provider import get_yaml_instance
+
+__all__ = [
+    'apply',
+    'build',
+    'get_st_resource',
+    'get_yaml_instance',
+    'process_macros',
+    'raw_macro',
+]

--- a/build_yaml_macros.py
+++ b/build_yaml_macros.py
@@ -2,8 +2,9 @@ import sublime
 import sublime_plugin
 
 from YAMLMacros.api import build
-from YAMLMacros.src.output_panel import OutputPanel
 from YAMLMacros.src.error_highlighter import ErrorHighlighter
+from YAMLMacros.src.output_panel import OutputPanel
+
 
 class BuildYamlMacrosCommand(sublime_plugin.WindowCommand):
     def run(self, *, source_path=None, target_path=None, working_dir=None, arguments=None, build_id='YAMLMacros'):
@@ -25,6 +26,7 @@ class BuildYamlMacrosCommand(sublime_plugin.WindowCommand):
             error_stream=error_stream,
             error_highlighter=ErrorHighlighter(self.window, 'YAMLMacros'),
         )
+
 
 class ClearViewCommand(sublime_plugin.TextCommand):
     def run(self, edit):

--- a/examples/basic/example_macros.py
+++ b/examples/basic/example_macros.py
@@ -1,2 +1,2 @@
-def fancy(str):
-    return '=== %s ===' % str.capitalize()
+def fancy(string):
+    return '=== %s ===' % string.capitalize()

--- a/examples/sql_syntax/sql.sublime-syntax
+++ b/examples/sql_syntax/sql.sublime-syntax
@@ -55,7 +55,7 @@ contexts:
         -   - meta_scope: meta.from.sql
             - match: ''
               pop: true
-        -                    
+        -
 
             - match: '{{var_name}}'
               scope: variable.other.table.sql
@@ -127,7 +127,7 @@ contexts:
 
     - include: else-pop
 
-  variable:             
+  variable:
 
     - match: '{{var_name}}'
       scope: variable.other.table.sql

--- a/examples/sql_syntax/sql_macros.py
+++ b/examples/sql_syntax/sql_macros.py
@@ -1,11 +1,26 @@
-from YAMLMacros.lib.syntax import meta, expect, pop_on, stack, rule
+from YAMLMacros.lib.syntax import expect, meta, pop_on, rule, stack
 
-def word(str):
-    return r'(?:\b(?i:%s)\b)' % str
+__all__ = [
+    # re-export macros from lib.syntax
+    'expect',
+    'meta',
+    'pop_on',
+    'rule',
+    'stack',
+    # define new macros
+    'word',
+    'identifier',
+    'expect_identifier',
+]
+
+
+def word(string):
+    return r'(?:\b(?i:%s)\b)' % string
+
 
 def identifier(scope):
     return [
-        rule( match=r'{{var_name}}', scope=scope, pop=True ),
+        rule(match=r'{{var_name}}', scope=scope, pop=True),
         rule(
             match=r'"',
             scope="punctuation.definition.string.begin.sql",
@@ -15,7 +30,8 @@ def identifier(scope):
                 rule(match=r'"', scope="punctuation.definition.string.end.sql", pop=True),
             ],
         ),
-    ] 
+    ]
+
 
 def expect_identifier(scope):
-    return identifier(scope) + [ rule(match=r'(?=\S)', pop=True) ]
+    return identifier(scope) + [rule(match=r'(?=\S)', pop=True)]

--- a/lib/arguments.py
+++ b/lib/arguments.py
@@ -1,7 +1,8 @@
+import copy
+
 from YAMLMacros.api import apply as _apply
 from YAMLMacros.api import raw_macro
 
-import copy
 
 @raw_macro
 def argument(name, default=None, *, eval, arguments):
@@ -12,6 +13,7 @@ def argument(name, default=None, *, eval, arguments):
     else:
         return None
 
+
 @raw_macro
 def if_(condition, then, else_=None, *, eval):
     if eval(condition):
@@ -21,9 +23,11 @@ def if_(condition, then, else_=None, *, eval):
     else:
         return None
 
+
 @raw_macro
 def with_(bindings, value, *, eval):
     return eval(value, eval(bindings))
+
 
 @raw_macro
 def foreach(in_, value, *, as_=None, eval):
@@ -63,6 +67,7 @@ def foreach(in_, value, *, as_=None, eval):
         })
         for k, v in items
     ]
+
 
 @raw_macro
 def format(string, bindings=None, *, eval, arguments):

--- a/lib/extend.py
+++ b/lib/extend.py
@@ -4,9 +4,11 @@ from functools import reduce
 from YAMLMacros.api import get_yaml_instance
 from YAMLMacros.src.util import deprecated, flatten
 
-class Operation():
+
+class Operation:
     def __init__(self, extension):
         self.extension = extension
+
 
 class Merge(Operation):
     def apply(self, base):
@@ -20,9 +22,11 @@ class Merge(Operation):
 
         return ret
 
+
 class Prepend(Operation):
     def apply(self, base):
         return self.extension + base
+
 
 class All(Operation):
     def apply(self, base):
@@ -32,13 +36,19 @@ class All(Operation):
             base,
         )
 
+
 def merge(*items): return Merge(OrderedDict(items))
+
+
 def prepend(*items): return Prepend(list(items))
+
+
 def all(*items): return All(list(items))
 
 
 def apply(base, *extensions):
     return all(*extensions).apply(base)
+
 
 @deprecated('Use !apply instead.')
 def extend(*items):

--- a/lib/include.py
+++ b/lib/include.py
@@ -1,18 +1,20 @@
 from YAMLMacros.api import process_macros
 
+
 def include(path):
     with open(path, 'r') as file:
         return process_macros(
             file.read(),
-            arguments={ "file_path": path },
+            arguments={"file_path": path},
         )
+
 
 def include_resource(resource):
     import sublime
     import os
-    file_path = os.path.join( sublime.packages_path(), resource )
+    file_path = os.path.join(sublime.packages_path(), resource)
     file_contents = sublime.load_resource(resource)
     return process_macros(
         file_contents,
-        arguments={ "file_path": file_path },
+        arguments={"file_path": file_path},
     )

--- a/lib/syntax.py
+++ b/lib/syntax.py
@@ -2,11 +2,13 @@ from collections import OrderedDict
 
 _RULE_KEYS = ['match', 'scope', 'captures', 'push', 'set', 'pop', 'embed', 'escape', 'with_prototype']
 
+
 def _rule_key_order(key):
     try:
         return _RULE_KEYS.index(key)
     except ValueError:
         return 0
+
 
 def rule(**args):
     return OrderedDict(sorted(
@@ -14,11 +16,13 @@ def rule(**args):
         key=lambda kv: _rule_key_order(kv[0]),
     ))
 
+
 def meta(scope):
     return [
         rule(meta_scope=scope),
         rule(match=r'', pop=True),
     ]
+
 
 def expect(expr, scope, set_context=None):
     ret = [
@@ -33,11 +37,13 @@ def expect(expr, scope, set_context=None):
 
     return ret
 
+
 def pop_on(expr):
     return rule(
         match=r'(?=(?:%s))' % expr,
         pop=True
     )
+
 
 def stack(*contexts):
     return [

--- a/src/build.py
+++ b/src/build.py
@@ -1,12 +1,10 @@
 import os
-from os import path
-import traceback
 import time
+import traceback
+from os import path
 
-from YAMLMacros.api import process_macros
-from YAMLMacros.api import get_yaml_instance
-from YAMLMacros.src.engine import MacroError
-
+from YAMLMacros.src.engine import MacroError, process_macros
+from YAMLMacros.src.yaml_provider import get_yaml_instance
 
 EXT_DOT_SUBLIME_SYNTAX_YAML_MACROS = '.sublime-syntax.yaml-macros'
 
@@ -66,7 +64,8 @@ def build(source_path, target_path, error_stream, arguments, error_highlighter):
             # Just a regular message, shouldn't be right-aligned.
             error_stream.print()
             error_stream.print('Error: Source is not a YAML Macros file!')
-            error_stream.print('Hint: Make sure source file has `{}` extension.'.format(EXT_DOT_SUBLIME_SYNTAX_YAML_MACROS))
+            error_stream.print('Hint: Make sure source file has `{}` extension.'
+                               .format(EXT_DOT_SUBLIME_SYNTAX_YAML_MACROS))
             error_stream.print()
             raise SilentException()
 

--- a/src/context.py
+++ b/src/context.py
@@ -1,16 +1,20 @@
 import threading
 from contextlib import contextmanager
+
 from YAMLMacros.src.util import merge
 
 _ns = threading.local()
 
+
 def _get_context_stack():
     if 'context' not in _ns.__dict__:
-        _ns.context = [ {} ]
+        _ns.context = [{}]
     return _ns.context
+
 
 def get_context():
     return _get_context_stack()[-1]
+
 
 @contextmanager
 def set_context(**kwargs):

--- a/src/error_highlighter.py
+++ b/src/error_highlighter.py
@@ -1,10 +1,11 @@
 import sublime
 
-PHANTOM_TEMPLATE="""
+PHANTOM_TEMPLATE = """
 <div class="error">{}</div>
 """
 
-class ErrorHighlighter():
+
+class ErrorHighlighter:
     def __init__(self, window, name, *, clear=True):
         self.window = window
         self.name = name

--- a/src/output_panel.py
+++ b/src/output_panel.py
@@ -1,11 +1,11 @@
-class OutputPanel():
+class OutputPanel:
     def __init__(self, window, name, *, clear=True, show=True):
         self.window = window
         self.name = name
 
         self.view = (
-            self.window.find_output_panel(self.name) or
-            self.window.create_output_panel(self.name)
+                self.window.find_output_panel(self.name) or
+                self.window.create_output_panel(self.name)
         )
 
         if clear: self.clear()

--- a/src/sublime_resources.py
+++ b/src/sublime_resources.py
@@ -1,15 +1,15 @@
-from os import path, walk, sep
-from zipfile import ZipFile
-import glob
 import fnmatch
+import glob
 import platform
-
+from os import path, sep, walk
+from zipfile import ZipFile
 
 platform_data_paths = {
     'Windows': r'%APPDATA%\Sublime Text 3',
     'Linux': path.expanduser('~/.config/sublime-text-3'),
-    'Darwin': path.expanduser(r'~/Library/Application Support/Sublime Text 3'),
+    'Darwin': path.expanduser('~/Library/Application Support/Sublime Text 3'),
 }
+
 
 def get_portable_st_data_path(potential_parent_of):
     """Given a path like H:\\STPortable\\3156\\Data\\Packages\\JavaScript\\JavaScript.sublime-syntax,
@@ -21,8 +21,10 @@ def get_portable_st_data_path(potential_parent_of):
         return None
     return path.join(after_split[0], 'Data', '')
 
+
 def get_st_data_path():
     return path.expandvars(platform_data_paths[platform.system()])
+
 
 def find_st_resources(data_path, installation_path, glob_pattern):
     """
@@ -31,42 +33,48 @@ def find_st_resources(data_path, installation_path, glob_pattern):
         - files in a .sublime-package file in the Installed Packages folder
         - files in a .sublime-package file in the ST installation Packages folder
           (where no .sublime-package file with the same name exists in the Installed Packages folder)
-        and then sort them according to lexographical order (ignoring duplicate results)
+        and then sort them according to lexicographical order (ignoring duplicate results)
          (except with Default coming first and User last)
     """
     matches = list()
-    def found_match(path):
+
+    def found_match(match_path):
         # switch matches to use `/` folder sep if necessary (i.e. on Windows)
         if sep == '\\':
-            path = path.replace('\\', '/')
-        matches.append(path)
-    
-    # if a path separator exists in the glob pattern then there is no need to try to find anything - no filename will match
-    if not '/' in glob_pattern:
+            match_path = match_path.replace('\\', '/')
+        matches.append(match_path)
+
+    # if a path separator exists in the glob pattern then
+    # there is no need to try to find anything - no filename will match
+    if '/' not in glob_pattern:
         # loose files in the data Packages folder
         for root, dirnames, filenames in walk(path.join(data_path, 'Packages'), followlinks=True):
             for filepath in [path.join(root, filename)[len(path.join(data_path, '')):] for filename in filenames]:
                 if glob_matches_filepath(filepath, glob_pattern):
                     found_match(filepath)
-        
+
         # for each .sublime-package file in the Installed Packages folder
         for zipfile_path in glob.iglob(path.join(data_path, 'Installed Packages', '*.sublime-package')):
             matches += find_files_matching_glob_in_zip(zipfile_path, glob_pattern)
-        
-        # search Packages subfolder of ST installation folder, where no .sublime-package file with the same name exists in the Installed Packages folder)
+
+        # search Packages sub-folder of ST installation folder,
+        # where no .sublime-package file with the same name exists in the Installed Packages folder
         for zipfile_path in glob.iglob(path.join(installation_path, 'Packages', '*.sublime-package')):
             if not path.isfile(path.join(data_path, 'Installed Packages', path.basename(zipfile_path))):
                 matches += find_files_matching_glob_in_zip(zipfile_path, glob_pattern)
-        
+
     # use a set to remove duplicates - no such thing as an ordered set in Python 3.3, so convert back to a list
     matches = list(set(matches))
-    return sorted(matches, key=get_sortkey_for_package_filepath)
+    return sorted(matches, key=get_sort_key_for_package_filepath)
+
 
 def glob_matches_filepath(filepath, glob_pattern):
     return fnmatch.fnmatchcase(path.basename(filepath), glob_pattern)
 
+
 def get_package_name_from_zipfile_name(zipfile_path):
     return path.splitext(path.basename(zipfile_path))[0]
+
 
 def find_files_matching_glob_in_zip(zipfile_path, glob_pattern):
     package_name = get_package_name_from_zipfile_name(zipfile_path)
@@ -77,11 +85,13 @@ def find_files_matching_glob_in_zip(zipfile_path, glob_pattern):
     # find any that match the glob
     return [file for file in files if glob_matches_filepath(file, glob_pattern)]
 
+
 def split_package_filepath(package_path):
     """Return a tuple with 2 args - the package name and the sub path inside the package."""
     return package_path[len('Packages/'):].split('/', 1)
 
-def get_sortkey_for_package_filepath(file_path):
+
+def get_sort_key_for_package_filepath(file_path):
     package_name, sub_path = split_package_filepath(file_path)
     index = 1
     if package_name == 'Default':
@@ -90,6 +100,7 @@ def get_sortkey_for_package_filepath(file_path):
         index = 2
     return str(index) + '/' + package_name + '/' + sub_path
 
+
 def load_st_resource(data_path, installation_path, package_path):
     if package_path.startswith('Packages/'):
         # if the file exists in the Packages folder, return that
@@ -97,16 +108,16 @@ def load_st_resource(data_path, installation_path, package_path):
         if path.isfile(full_path):
             with open(full_path, 'r', encoding='utf-8') as file:
                 return file.read()
-        
+
         # otherwise, it must exist in a .sublime-package file, if at all
         # so find the Package name, and the path inside the zip file
         package_name, sub_path = split_package_filepath(package_path)
-        
+
         # look in the relevant Installed Packages .sublime-package file, if it exists
         full_path = path.join(data_path, 'Installed Packages', package_name + '.sublime-package')
         if path.isfile(full_path):
             return get_file_from_zip(full_path, sub_path)
-        
+
         # otherwise, try the ST installation path
         full_path = path.join(installation_path, 'Packages', package_name + '.sublime-package')
         if path.isfile(full_path):
@@ -114,14 +125,17 @@ def load_st_resource(data_path, installation_path, package_path):
 
     raise IOError('resource not found')
 
+
 def get_files_in_zip(zipfile_path):
     with ZipFile(zipfile_path, 'r') as z:
         return z.namelist()
+
 
 def get_file_from_zip(zipfile_path, path_inside_zip):
     with ZipFile(zipfile_path, 'r') as z:
         with z.open(path_inside_zip, 'r') as file:
             return file.read().decode(encoding='utf-8')
+
 
 def get_st_installation_folder():
     if platform.system() == 'Windows':
@@ -129,10 +143,10 @@ def get_st_installation_folder():
         with winreg.OpenKey(winreg.HKEY_CLASSES_ROOT, r'*\shell\Open with Sublime Text\command') as key:
             exe = winreg.QueryValue(key, None)
     else:
-        # https://stackoverflow.com/a/39149470/4473405
         import shutil
         exe = shutil.which('subl')
     return path.dirname(exe)
+
 
 def get_st_resource(resource, data_path_possible_parent_of=None):
     data_path = None
@@ -151,4 +165,4 @@ def get_st_resource(resource, data_path_possible_parent_of=None):
         else:
             resource = ''
 
-    return (resource, load_st_resource(data_path, installation_path, resource))
+    return resource, load_st_resource(data_path, installation_path, resource)

--- a/src/yaml_provider.py
+++ b/src/yaml_provider.py
@@ -1,5 +1,7 @@
-import ruamel.yaml
 from collections import OrderedDict
+
+import ruamel.yaml
+
 
 def clone_class(klass):
     return type(
@@ -8,10 +10,11 @@ def clone_class(klass):
         {}
     )
 
+
 def get_yaml_instance(
-    version=(1, 2),
-    indent=None,
-    **kwargs
+        version=(1, 2),
+        indent=None,
+        **kwargs
 ):
     if indent is None:
         indent = {'mapping': 2, 'sequence': 4, 'offset': 2}
@@ -21,8 +24,9 @@ def get_yaml_instance(
     yaml.Representer = clone_class(yaml.Representer)
 
     yaml.version = version
-    yaml.indent(**indent);
+    yaml.indent(**indent)
 
-    yaml.Representer.add_representer(OrderedDict, lambda self, data: self.represent_mapping('tag:yaml.org,2002:map', data))
+    yaml.Representer.add_representer(OrderedDict,
+                                     lambda self, data: self.represent_mapping('tag:yaml.org,2002:map', data))
 
     return yaml


### PR DESCRIPTION
Mostly cleans up code style, including but limited to
  - white-space fixes,
  - imports ordering,
  - built-in name shadowing (except keyword-only arguments such as
    widely used `eval`).

* src/engine.py:apply_transformation:

  Adds safeguard `else` branch. Otherwise variable `args` theoretically
  might get referenced before assignment.

* src/sublime_resources.py:

  (find_st_resources): Fixes typo in docstring.
  (get_st_installation_folder):
    Removes commented out link to StackOverflow answer about shutil:
    there were nothing going on which wouldn't have been covered by
    official Python docs.

---

Most of this is an automatic `Ctrl`+`Alt`+`Shift`+`L` in PyCharm, except that I had to be extra careful in actual macro plugins (for the reasons ~I'm gonna describe in an upcoming issue soon~ described in #41).